### PR TITLE
Fix crash on multiple rounds

### DIFF
--- a/runner.rb
+++ b/runner.rb
@@ -890,7 +890,7 @@ class Runner
             results[i][:score] = bot[:score]
             results[i][:disqualified_for] = bot[:disqualified_for]
             results[i][:stderr_lines] = bot[:stderr_lines]
-            if @profile
+            if @profile || @rounds > 1
                 results[i][:gem_utilization] = (ttl_spawned > 0 ? (bot[:score].to_f / ttl_spawned.to_f * 100.0 * 100).to_i.to_f / 100 : 0.0)
                 results[i][:tile_coverage] = ((@tiles_revealed[i] & @floor_tiles_set).size.to_f / @floor_tiles_set.size.to_f * 100.0 * 100).to_i.to_f / 100
             end


### PR DESCRIPTION
fix: track gem_utilization when running multiple rounds without profiling. Fixes #2