### PR TITLE
Adjust gem utilization initialization condition

### DIFF
--- a/runner.rb
+++ b/runner.rb
@@ -1423,7 +1423,7 @@ class Runner
         @bots.each.with_index do |bot, i|
             results[i][:score] = bot[:score]
             results[i][:disqualified_for] = bot[:disqualified_for]
-            if @profile
+            if @profile || @rounds > 1
                 results[i][:gem_utilization] = (ttl_spawned > 0 ? (bot[:score].to_f / ttl_spawned.to_f * 100.0 * 100).to_i.to_f / 100 : 0.0)
                 results[i][:tile_coverage] = ((@tiles_revealed[i] & @floor_tiles_set).size.to_f / @floor_tiles_set.size.to_f * 100.0 * 100).to_i.to_f / 100
             end


### PR DESCRIPTION
"ruby runner.rb -r 2 v 1" raises TypeError because of missing initialization.
```
runner.rb:1722:in 'Float#+': nil can't be coerced into Float (TypeError)

        mean  = all_utilization[i].sum(0.0) / n
                                       ^^^
        from runner.rb:1722:in 'Array#sum'
        from runner.rb:1722:in 'block in <main>'
        from runner.rb:1719:in 'Array#each'
        from runner.rb:1719:in 'Enumerator#with_index'
        from runner.rb:1719:in '<main>'
```