### PR TITLE
Bun path not added to Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,6 +104,7 @@ RUN mkdir -p /home/runner/.cargo && echo "[source.crates-io]\nreplace-with = \"v
 
 # Install Bun
 RUN curl -fsSL https://bun.com/install | bash
+ENV PATH="/home/runner/.bun/bin:$PATH"
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 


### PR DESCRIPTION
Using bun with the runner will result in a `bun: not found` error because the `Dockerfile` doesn't actually add bun's path to the runner user. This PR should fix that _(tested locally with --use-docker option)_