### PR TITLE
Sanitize emojis

### DIFF
--- a/runner.rb
+++ b/runner.rb
@@ -590,6 +590,11 @@ class Runner
         Unicode::DisplayWidth.of(str.to_s, emoji: true, ambwidth: 1)
     end
 
+    def sanitize_emoji(str)
+        # Remove all characters with a width <= 0 from the string
+        str.each_grapheme_cluster.select { |g| vwidth(g) > 0 }.join
+    end
+
     def trim_ansi_to_width(str, max_width)
         ss      = StringScanner.new(str)
         out     = +""
@@ -913,7 +918,7 @@ class Runner
         if File.exist?(yaml_path)
             info = YAML.load(File.read(yaml_path))
             @bots.last[:name] = info['name'] if info['name'].is_a?(String)
-            @bots.last[:emoji] = info['emoji'] if info['emoji'].is_a?(String)
+            @bots.last[:emoji] = sanitize_emoji(info['emoji'].to_s) if info['emoji'].is_a?(String)
             if vwidth(@bots.last[:emoji]) > 2
                 raise "Error in bot.yaml: emoji must be at most 2 characters wide (#{@bots.last[:emoji]} is #{vwidth(@bots.last[:emoji])} characters wide)"
             end


### PR DESCRIPTION
The [Unicode::DisplayWidth gem](https://github.com/janlelis/unicode-display_width?tab=readme-ov-file#introduction-to-character-widths) used to determine the display width of user emojis handles some special characters as -1 or 0 length. This makes it possible to enter long text as the emoji by padding the string with backspaces `\b` until its computed length is below 2 again or break the display with carriage returns `\r` or line feeds `\n`.

This PR adds a sanitization function that removes all characters from the emoji that have a length <=0 when parsing the config, thus preventing the above.

I created a short test script on a different branch, that makes sure that existing emojis aren't affected by this, which can be found here: https://github.com/IceFreez3r/hidden-gems/commit/be783a62d40c6e7d227c51ba18ed5ca874272199