### PR TITLE
Fix random gem_spawn_rate distribution

### DIFF
--- a/runner.rb
+++ b/runner.rb
@@ -323,8 +323,8 @@ class Runner
             value = instance_variable_get(key)
             if value.is_a?(String) && value.include?('..')
                 parts = value.split('..').map { |x| x.strip.to_f }
-                new_value = parts[0] + param_rng.next_float * (parts[1] - parts[0])
-                new_value = (new_value * 100.0).round() / 100.0
+                new_value = parts[0] + param_rng.next_float * (parts[1] - parts[0] + 1)
+                new_value = (new_value * 100.0).floor() / 100.0
                 instance_variable_set(key, new_value)
             end
         end


### PR DESCRIPTION
With the old version the lower and upper limit of the gem_spawn_rate had a 50% lower chance to appear. This PR gives them equal probabilties.

E.g. for `gem_spawn_rate: 0.04..0.06` a random number from [0.04, 0.06) was generated and then rounded:
[0.04, 0.045) -> 0.04
[0.45, 0.55) -> 0.05
[0.55, 0.6) -> 0.06

The new version generates a number in [0.04, 0.07) and floors it:
[0.04, 0.05) -> 0.04 
[0.05, 0.06) -> 0.05
[0.06, 0.07) -> 0.06