### PR TITLE
Update runner.rb - fix broken gem_spawn_rate 

### DIFF
--- a/runner.rb
+++ b/runner.rb
@@ -207,7 +207,7 @@ class Runner
             value = instance_variable_get(key)
             if value.is_a?(String) && value.include?('..')
                 parts = value.split('..').map { |x| x.strip.to_f }
-                new_value = parts[0] + param_rng.next_float * (parts[1] - parts[0] + 1)
+                new_value = parts[0] + param_rng.next_float * (parts[1] - parts[0])
                 new_value = (new_value * 100.0).floor() / 100.0
                 instance_variable_set(key, new_value)
             end


### PR DESCRIPTION


fixing the fix
gem_rates before fix (sample of 12 rounds)
0.06 0.09 0.25 0.34 0.39 0.44 0.48 0.56 0.61 0.82

after fix (same seeds)
0.04 0.05 0.06
